### PR TITLE
Add flag for enabling sudo on the openconnect subprocess

### DIFF
--- a/openconnect-gp-okta
+++ b/openconnect-gp-okta
@@ -101,7 +101,8 @@ def complete_saml(s, saml_resp_url, saml_resp_data):
 @click.option('--username')
 @click.option('--password')
 @click.option('--totp-key')
-def main(gateway, openconnect_args, username, password, totp_key):
+@click.option('--sudo/--no-sudo', default=False)
+def main(gateway, openconnect_args, username, password, totp_key, sudo):
     if (totp_key is not None) and (pyotp is None):
         print('--totp-key requires pyotp!', file=sys.stderr)
         sys.exit(1)
@@ -124,6 +125,9 @@ def main(gateway, openconnect_args, username, password, totp_key):
         '--usergroup=gateway:prelogin-cookie',
         '--passwd-on-stdin'
     ] + list(openconnect_args)
+
+    if sudo:
+        subprocess_args = ['sudo'] + subprocess_args
 
     with subprocess.Popen(subprocess_args, stdin=subprocess.PIPE) as p:
         p.communicate(input=prelogin_cookie.encode())

--- a/openconnect-gp-okta
+++ b/openconnect-gp-okta
@@ -116,9 +116,16 @@ def main(gateway, openconnect_args, username, password, totp_key):
         saml_resp_url, saml_resp_data = okta_saml(s, saml_req_url, username, password, totp_key)
         saml_username, prelogin_cookie = complete_saml(s, saml_resp_url, saml_resp_data)
 
-    with subprocess.Popen(['openconnect', gateway, '--protocol=gp', '--user=' + saml_username,
-            '--usergroup=gateway:prelogin-cookie', '--passwd-on-stdin'] +
-            list(openconnect_args), stdin=subprocess.PIPE) as p:
+    subprocess_args = [
+        'openconnect',
+        gateway,
+        '--protocol=gp',
+        '--user=' + saml_username,
+        '--usergroup=gateway:prelogin-cookie',
+        '--passwd-on-stdin'
+    ] + list(openconnect_args)
+
+    with subprocess.Popen(subprocess_args, stdin=subprocess.PIPE) as p:
         p.communicate(input=prelogin_cookie.encode())
 
 main()


### PR DESCRIPTION
The openconnect process needs to be run as root so that it can configure the network interfaces, but I don't feel comfortable running the entire wrapper as sudo. With this change you can add the `--sudo` flag to run the subprocess only as root. It is by default disabled (and can also explicitly disabled with `--no-sudo`)