### PR TITLE
Make into package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
+# IDEs
 /.idea/
+/.venv/
+
+# Caches
 __pycache__/
+
+# Build files
+/dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-yaml
+  - id: double-quote-string-fixer
+- repo: https://github.com/ambv/black
+  rev: 21.12b0
+  hooks:
+  - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
   rev: 21.12b0
   hooks:
   - id: black
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.2.0
   hooks:
   - id: check-yaml
   - id: double-quote-string-fixer
 - repo: https://github.com/ambv/black
-  rev: 21.12b0
+  rev: 22.3.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 zdave
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/openconnect_gp_okta.py
+++ b/openconnect_gp_okta.py
@@ -12,43 +12,60 @@ import requests
 import signal
 import subprocess
 import sys
-import urllib
+import urllib.parse
 
 try:
     import pyotp
 except ImportError:
     pyotp = None
 
-def check(r):
+
+def check(r: requests.Response):
     r.raise_for_status()
     return r
 
-def extract_form(html):
-    form = lxml.etree.fromstring(html, lxml.etree.HTMLParser()).find('.//form')
-    return (form.attrib['action'],
-        {inp.attrib['name']: inp.attrib['value'] for inp in form.findall('input')})
 
-def prelogin(s, gateway):
+def extract_form(html: str):
+    form = lxml.etree.fromstring(html, lxml.etree.HTMLParser()).find('.//form')
+    return (
+        form.attrib['action'],
+        {inp.attrib['name']: inp.attrib['value'] for inp in form.findall('input')},
+    )
+
+
+def prelogin(s: requests.Session, gateway: str):
     r = check(s.post('https://{}/ssl-vpn/prelogin.esp'.format(gateway)))
-    saml_req_html = base64.b64decode(lxml.etree.fromstring(r.content).find('saml-request').text)
+    saml_req_html = base64.b64decode(
+        lxml.etree.fromstring(r.content).find('saml-request').text
+    )
     saml_req_url, saml_req_data = extract_form(saml_req_html)
     assert 'SAMLRequest' in saml_req_data
     return saml_req_url + '?' + urllib.parse.urlencode(saml_req_data)
 
-def post_json(s, url, data):
-    r = check(s.post(url, data=json.dumps(data),
-        headers={'Content-Type': 'application/json'}))
+
+def post_json(s: requests.Session, url: str, data: object):
+    r = check(
+        s.post(url, data=json.dumps(data), headers={'Content-Type': 'application/json'})
+    )
     return r.json()
 
-def okta_auth(s, domain, username, password, totp_key):
-    r = post_json(s, 'https://{}/api/v1/authn'.format(domain),
-        {'username': username, 'password': password})
+
+def okta_auth(
+    s: requests.Session, domain: str, username: str, password: str, totp_key: str | None
+):
+    r = post_json(
+        s,
+        'https://{}/api/v1/authn'.format(domain),
+        {'username': username, 'password': password},
+    )
 
     if r['status'] == 'MFA_REQUIRED':
-        def priority(factor):
-            return {
-                'token:software:totp': 2 if totp_key is None else 0,
-                'push': 1}.get(factor['factorType'], 2)
+
+        def priority(factor: dict[str, str]):
+            return {'token:software:totp': 2 if totp_key is None else 0, 'push': 1}.get(
+                factor['factorType'], 2
+            )
+
         for factor in sorted(r['_embedded']['factors'], key=priority):
             if factor['factorType'] == 'push':
                 url = factor['_links']['verify']['href']
@@ -69,10 +86,16 @@ def okta_auth(s, domain, username, password, totp_key):
                 url = factor['_links']['verify']['href']
                 r = post_json(s, url, {'stateToken': r['stateToken']})
                 assert r['status'] == 'MFA_CHALLENGE'
-                if (factor['factorType'] == 'token:software:totp') and (totp_key is not None):
+                if (factor['factorType'] == 'token:software:totp') and (
+                    totp_key is not None
+                ):
                     code = pyotp.TOTP(totp_key).now()
                 else:
-                    code = input('One-time code for {} ({}): '.format(factor['provider'], factor['vendorName']))
+                    code = input(
+                        'One-time code for {} ({}): '.format(
+                            factor['provider'], factor['vendorName']
+                        )
+                    )
                 r = post_json(s, url, {'stateToken': r['stateToken'], 'passCode': code})
                 break
         else:
@@ -81,7 +104,14 @@ def okta_auth(s, domain, username, password, totp_key):
     assert r['status'] == 'SUCCESS'
     return r['sessionToken']
 
-def okta_saml(s, saml_req_url, username, password, totp_key):
+
+def okta_saml(
+    s: requests.Session,
+    saml_req_url: str,
+    username: str,
+    password: str,
+    totp_key: str | None,
+):
     domain = urllib.parse.urlparse(saml_req_url).netloc
 
     # Just to set DT cookie
@@ -89,43 +119,57 @@ def okta_saml(s, saml_req_url, username, password, totp_key):
 
     token = okta_auth(s, domain, username, password, totp_key)
 
-    r = check(s.get('https://{}/login/sessionCookieRedirect'.format(domain),
-        params={'token': token, 'redirectUrl': saml_req_url}))
+    r = check(
+        s.get(
+            'https://{}/login/sessionCookieRedirect'.format(domain),
+            params={'token': token, 'redirectUrl': saml_req_url},
+        )
+    )
     saml_resp_url, saml_resp_data = extract_form(r.content)
     assert 'SAMLResponse' in saml_resp_data
     return saml_resp_url, saml_resp_data
 
-def complete_saml(s, saml_resp_url, saml_resp_data):
+
+def complete_saml(
+    s: requests.Session, saml_resp_url: str, saml_resp_data: dict[str, object]
+):
     r = check(s.post(saml_resp_url, data=saml_resp_data))
     return r.headers['saml-username'], r.headers['prelogin-cookie']
 
+
 @contextlib.contextmanager
-def signal_mask(how, mask):
+def signal_mask(how: int, mask: set[signal.Signals]):
     old_mask = signal.pthread_sigmask(how, mask)
     try:
         yield old_mask
     finally:
         signal.pthread_sigmask(signal.SIG_SETMASK, old_mask)
 
+
 @contextlib.contextmanager
-def signal_handler(num, handler):
+def signal_handler(num: signal.Signals, handler: callable):
     old_handler = signal.signal(num, handler)
     try:
         yield old_handler
     finally:
         signal.signal(num, old_handler)
 
+
 @contextlib.contextmanager
-def popen_forward_sigterm(args, *, stdin=None):
+def popen_forward_sigterm(args: list[str], *, stdin=None):
     with signal_mask(signal.SIG_BLOCK, {signal.SIGTERM}) as old_mask:
-        with subprocess.Popen(args, stdin=stdin,
-                preexec_fn=lambda: signal.pthread_sigmask(signal.SIG_SETMASK, old_mask)) as p:
+        with subprocess.Popen(
+            args,
+            stdin=stdin,
+            preexec_fn=lambda: signal.pthread_sigmask(signal.SIG_SETMASK, old_mask),
+        ) as p:
             with signal_handler(signal.SIGTERM, lambda *args: p.terminate()):
                 with signal_mask(signal.SIG_SETMASK, old_mask):
                     yield p
                     if p.stdin:
                         p.stdin.close()
                     os.waitid(os.P_PID, p.pid, os.WEXITED | os.WNOWAIT)
+
 
 @click.command()
 @click.argument('gateway')
@@ -134,7 +178,14 @@ def popen_forward_sigterm(args, *, stdin=None):
 @click.option('--password')
 @click.option('--totp-key')
 @click.option('--sudo/--no-sudo', default=False)
-def main(gateway, openconnect_args, username, password, totp_key, sudo):
+def main(
+    gateway: str,
+    openconnect_args: list[str],
+    username: str | None,
+    password: str | None,
+    totp_key: str | None,
+    sudo: bool,
+):
     if (totp_key is not None) and (pyotp is None):
         print('--totp-key requires pyotp!', file=sys.stderr)
         sys.exit(1)
@@ -146,7 +197,9 @@ def main(gateway, openconnect_args, username, password, totp_key, sudo):
 
     with requests.Session() as s:
         saml_req_url = prelogin(s, gateway)
-        saml_resp_url, saml_resp_data = okta_saml(s, saml_req_url, username, password, totp_key)
+        saml_resp_url, saml_resp_data = okta_saml(
+            s, saml_req_url, username, password, totp_key
+        )
         saml_username, prelogin_cookie = complete_saml(s, saml_resp_url, saml_resp_data)
 
     subprocess_args = [
@@ -155,7 +208,7 @@ def main(gateway, openconnect_args, username, password, totp_key, sudo):
         '--protocol=gp',
         '--user=' + saml_username,
         '--usergroup=gateway:prelogin-cookie',
-        '--passwd-on-stdin'
+        '--passwd-on-stdin',
     ] + list(openconnect_args)
 
     if sudo:
@@ -165,4 +218,6 @@ def main(gateway, openconnect_args, username, password, totp_key, sudo):
         p.stdin.write(prelogin_cookie.encode())
     sys.exit(p.returncode)
 
-main()
+
+if __name__ == '__main__':
+    main()

--- a/openconnect_gp_okta.py
+++ b/openconnect_gp_okta.py
@@ -14,6 +14,7 @@ import urllib.parse
 from typing import Any, Callable, ContextManager, Optional, Tuple
 
 import click
+import keyring
 import lxml.etree
 import requests
 
@@ -203,7 +204,9 @@ def main(
     if username is None:
         username = input('Username: ')
     if password is None:
-        password = getpass.getpass()
+        password = keyring.get_password(gateway, username)
+        if password is None:
+            password = getpass.getpass()
 
     with requests.Session() as s:
         saml_req_url = prelogin(s, gateway)

--- a/openconnect_gp_okta.py
+++ b/openconnect_gp_okta.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 
 import base64
-import click
 import contextlib
 import getpass
 import json
-import lxml.etree
 import os
 import re
-import requests
 import signal
 import subprocess
 import sys
 import urllib.parse
+
+import click
+import lxml.etree
+import requests
 
 try:
     import pyotp

--- a/openconnect_gp_okta.py
+++ b/openconnect_gp_okta.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""OpenConnect wrapper which logs into a GlobalProtect gateway, authenticating with Okta."""
 
 import base64
 import contextlib
@@ -20,6 +21,9 @@ try:
     import pyotp
 except ImportError:
     pyotp = None
+
+
+__version__ = '1.0'
 
 
 def check(r: requests.Response) -> requests.Response:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = 'openconnect_gp_okta'
+authors = [{name = 'David Emett', email = 'dave@sp4m.net'}]
+classifiers = ['License :: OSI Approved :: MIT License']
+dynamic = ['version', 'description']
+dependencies = [
+    'certifi >=2020.12.5',
+    'chardet >=3.0.4, <4',
+    'click >=7.1.2',
+    'idna >=2.10, <3',
+    'lxml >=4.6.2, <5',
+    'requests >=2.25.0, <3',
+    'urllib3 >=1.26.2, <2',
+]
+
+[project.urls]
+Home = 'https://github.com/zdave/openconnect-gp-okta'
+
+[project.scripts]
+openconnect-gp-okta = 'openconnect_gp_okta:main'
+
+[tool.black]
+skip-string-normalization = true
+
+[build-system]
+requires = ['flit_core >=3.2,<4']
+build-backend = 'flit_core.buildapi'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = 'openconnect_gp_okta'
-authors = [{name = 'David Emett', email = 'dave@sp4m.net'}]
+authors = [
+    { name = 'David Emett', email = 'dave@sp4m.net' },
+    { name = 'Philipp Angerer', email = 'flying-sheep@web.de' },
+]
 classifiers = ['License :: OSI Approved :: MIT License']
 dynamic = ['version', 'description']
 dependencies = [
@@ -11,6 +14,7 @@ dependencies = [
     'lxml >=4.6.3, <5',
     'requests >=2.25.0, <3',
     'urllib3 >=1.26.2, <2',
+    'keyring >=23.4.0',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     'chardet >=3.0.4, <4',
     'click >=7.1.2',
     'idna >=2.10, <3',
-    'lxml >=4.6.2, <5',
+    'lxml >=4.6.3, <5',
     'requests >=2.25.0, <3',
     'urllib3 >=1.26.2, <2',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     'urllib3 >=1.26.2, <2',
 ]
 
+[project.optional-dependencies]
+totp = ['pyotp']
+
 [project.urls]
 Home = 'https://github.com/zdave/openconnect-gp-okta'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-certifi==2020.12.5
-chardet==3.0.4
-click==7.1.2
-idna==2.10
-lxml==4.6.3
-requests==2.25.0
-urllib3==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ certifi==2020.12.5
 chardet==3.0.4
 click==7.1.2
 idna==2.10
-lxml==4.6.2
+lxml==4.6.3
 requests==2.25.0
 urllib3==1.26.2


### PR DESCRIPTION
This way, people can just `pip install` it. This part means it’ll provide an executable called `openconnect-gp-okta` when installed.

https://github.com/zdave/openconnect-gp-okta/blob/f85a00295ccad1b15c24b3d946f93cf7a75df3f5/pyproject.toml#L22-L23

Other changes:

- format with `black` and `isort` (TODO: add to CI if you want that)
- add type annotations
- add MIT license (can be changed if you prefer another one)
- add `if __name__ == '__main__'` so people can import it without executing it
- update lxml to 4.6.3 so it can be used with Python 3.10

IDK if you want extensive changes like that, but I thought I’d offer.