### PR TITLE
Add support for FIDO2 WebAuthn MFA

### DIFF
--- a/openconnect-gp-okta
+++ b/openconnect-gp-okta
@@ -3,7 +3,6 @@
 import base64
 import click
 import contextlib
-import getpass
 import json
 import lxml.etree
 import os
@@ -60,7 +59,7 @@ def okta_auth(s, domain, username, password, factor_priorities, totp_key):
                 url = factor['_links']['verify']['href']
                 r = post_json(s, url, {'stateToken': r['stateToken']})
                 assert r['status'] == 'MFA_CHALLENGE'
-                code = input('SMS code: ')
+                code = click.prompt('SMS code')
                 r = post_json(s, url, {'stateToken': r['stateToken'], 'passCode': code})
                 break
             if re.match('token(?::|$)', factor['factorType']):
@@ -68,7 +67,7 @@ def okta_auth(s, domain, username, password, factor_priorities, totp_key):
                 if (factor['factorType'] == 'token:software:totp') and (totp_key is not None):
                     code = pyotp.TOTP(totp_key).now()
                 else:
-                    code = input('One-time code for {} ({}): '.format(factor['provider'], factor['vendorName']))
+                    code = click.prompt('One-time code for {} ({})'.format(factor['provider'], factor['vendorName']))
                 r = post_json(s, url, {'stateToken': r['stateToken'], 'passCode': code})
                 break
         else:
@@ -133,13 +132,13 @@ def popen_forward_sigterm(args, *, stdin=None):
 @click.option('--sudo/--no-sudo', default=False)
 def main(gateway, openconnect_args, username, password, factor_priorities, totp_key, sudo):
     if (totp_key is not None) and (pyotp is None):
-        print('--totp-key requires pyotp!', file=sys.stderr)
+        click.echo('--totp-key requires pyotp!', err=True)
         sys.exit(1)
 
     if username is None:
-        username = input('Username: ')
+        username = click.prompt('Username')
     if password is None:
-        password = getpass.getpass()
+        password = click.prompt('Password', hide_input=True)
 
     factor_priorities = {
         'token:software:totp': 0 if totp_key is None else 2,

--- a/openconnect-gp-okta
+++ b/openconnect-gp-okta
@@ -18,6 +18,94 @@ try:
 except ImportError:
     pyotp = None
 
+HAS_FIDO2 = True
+try:
+    from fido2.client import Fido2Client, UserInteraction
+    from fido2.hid import list_devices
+    from fido2.utils import websafe_decode, websafe_encode
+except ImportError:
+    HAS_FIDO2 = False
+    UserInteraction = object
+
+
+class ConsoleInteraction(UserInteraction):
+    def prompt_up(self):
+        """Called when the authenticator is awaiting a user presence check."""
+        click.echo("Touch your hardware token to confirm user presence")
+
+    def request_pin(self, permissions, rp_id):
+        """Called when the client requires a PIN from the user.
+        Should return a PIN, or None/Empty to cancel."""
+        return click.prompt("Enter your hardware token pin", hide_input=True)
+
+    def request_uv(self, permissions, rp_id):
+        """Called when the client is about to request UV from the user.
+        Should return True if allowed, or False to cancel."""
+        click.echo("User Verification requested.")
+        return True
+
+class OktaWebauthn:
+    # Not using factor['_links']['verify']['href'] as multiple
+    # webauthn devices may exist and Okta has an alternative
+    # workflow which works with any webauthn device available by
+    # querying a generic URL.
+    WEBAUTHN_URL_TEMPLATE = 'https://{}/api/v1/authn/factors/webauthn/verify'
+
+    def __init__(self):
+        assert HAS_FIDO2
+        self._device = None
+
+    def get_device(self):
+        self._device = next(list_devices(), None)
+        while self._device is None:
+            click.echo("Please insert a suitable device if you wish to continue with webauthn MFA.")
+            if click.confirm("Continue with webauthn MFA?"):
+                self._device = next(list_devices(), None)
+            else:
+                click.echo("Falling back to other MFA method.")
+                break
+        return self._device is not None
+
+    def okta_verify(self, session, domain, stateToken):
+        url = self.WEBAUTHN_URL_TEMPLATE.format(domain)
+        r = post_json(session, url, {'stateToken': stateToken})
+        assert r['status'] == 'MFA_CHALLENGE'
+
+        fido_client = Fido2Client(
+            self._device,
+            "https://{}".format(domain),
+            user_interaction=ConsoleInteraction(),
+        )
+        pubkey_req = {
+            "challenge": websafe_decode(r['_embedded']['challenge']['challenge']),
+            "rpId": domain,
+            'allowCredentials': [
+                {
+                    'type': 'public-key',
+                    'id': websafe_decode(f['profile']['credentialId'])
+                } for f in r['_embedded']['factors']
+            ]
+        }
+
+        assertion = fido_client.get_assertion(pubkey_req).get_response(0)
+
+        def b64(obj):
+            # websafe_encode(obj) takes a python object and serializes it using
+            # methods defined by this given object so that (obj !=
+            # websafe_decode(websafe_encode(obj))). The latter is a bytestring
+            # that then needs to be correctly base64 encoded for Okta.
+            return base64.b64encode(websafe_decode(websafe_encode(obj))).decode('ascii')
+
+        next_url = r['_links']['next']['href']
+        payload = {
+            'authenticatorData': b64(assertion['authenticatorData']),
+            'clientData': b64(assertion['clientData']),
+            'signatureData': b64(assertion['signature']),
+            'stateToken': r["stateToken"]
+        }
+        return post_json(session, next_url, payload)
+
+
 def check(r):
     r.raise_for_status()
     return r
@@ -46,6 +134,8 @@ def okta_auth(s, domain, username, password, factor_priorities, totp_key):
     if r['status'] == 'MFA_REQUIRED':
         def priority(factor):
             return factor_priorities.get(factor['factorType'], 0)
+
+        ignore_webauthn = not HAS_FIDO2
         for factor in sorted(r['_embedded']['factors'], key=priority, reverse=True):
             if factor['factorType'] == 'push':
                 url = factor['_links']['verify']['href']
@@ -61,6 +151,14 @@ def okta_auth(s, domain, username, password, factor_priorities, totp_key):
                 assert r['status'] == 'MFA_CHALLENGE'
                 code = click.prompt('SMS code')
                 r = post_json(s, url, {'stateToken': r['stateToken'], 'passCode': code})
+                break
+            if factor['factorType'] == 'webauthn' and not ignore_webauthn:
+                webauthn = OktaWebauthn()
+                if webauthn.get_device():
+                    r = webauthn.okta_verify(s, domain, r['stateToken'])
+                else:
+                    ignore_webauthn = True
+                    continue
                 break
             if re.match('token(?::|$)', factor['factorType']):
                 url = factor['_links']['verify']['href']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
 certifi==2022.5.18.1
+cffi==1.15.1
 chardet==4.0.0
 charset-normalizer==2.0.12
 click==8.1.3
+cryptography==38.0.1
+fido2==1.0.0
 idna==3.3
 lxml==4.8.0
+pycparser==2.21
 requests==2.27.1
 urllib3==1.26.9


### PR DESCRIPTION
Add Okta FIDO2 WebAuthn workflow as a possible second factor using the fido2 python library.

Use --factor-priority webauthn to change this new factor priority.

Signed-off-by: Alexis Lescouet <alexis@lescouet.com>